### PR TITLE
0.0.04 – Side Menu and Panel Wiring

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -8,10 +8,10 @@
         Title="TheWordForge"
         Width="1280" Height="720">
     <Grid RowDefinitions="Auto,*,Auto">
-        <menusTop:TopMenu Grid.Row="0"/>
+        <ContentControl Grid.Row="0" Content="{Binding CurrentTopMenu}"/>
         <Grid Grid.Row="1" ColumnDefinitions="15*,60*,25*">
             <menusSide:SideMenu Grid.Column="0"/>
-            <panels:CenterPanel Grid.Column="1"/>
+            <ContentControl Grid.Column="1" Content="{Binding CurrentCenterPanel}"/>
             <panes:RightPane Grid.Column="2"/>
         </Grid>
         <panels:StatusBar Grid.Row="2"/>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -7,5 +7,6 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        DataContext = new MainViewModel();
     }
 }

--- a/menus/side/SideMenu.axaml
+++ b/menus/side/SideMenu.axaml
@@ -1,5 +1,149 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:TheWordForge"
              x:Class="TheWordForge.menus.side.SideMenu">
-    <TextBlock Text="Side Menu Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e" Padding="5">
+        <StackPanel>
+            <Button Content="Transcript" Tag="Transcript" Click="Button_Click">
+                <Button.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="Background" Value="#2b2b2b"/>
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                        <Setter Property="Margin" Value="2"/>
+                    </Style>
+                    <Style Selector="Button:pointerover">
+                        <Setter Property="Background" Value="#3b3b3b"/>
+                    </Style>
+                    <Style Selector="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActivePanel}" Value="{x:Static vm:ActivePanel.Transcript}">
+                                <Setter Property="Background" Value="#555555"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Styles>
+            </Button>
+            <Button Content="Timeline" Tag="Timeline" Click="Button_Click">
+                <Button.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="Background" Value="#2b2b2b"/>
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                        <Setter Property="Margin" Value="2"/>
+                    </Style>
+                    <Style Selector="Button:pointerover">
+                        <Setter Property="Background" Value="#3b3b3b"/>
+                    </Style>
+                    <Style Selector="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActivePanel}" Value="{x:Static vm:ActivePanel.Timeline}">
+                                <Setter Property="Background" Value="#555555"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Styles>
+            </Button>
+            <Button Content="Outline" Tag="Outline" Click="Button_Click">
+                <Button.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="Background" Value="#2b2b2b"/>
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                        <Setter Property="Margin" Value="2"/>
+                    </Style>
+                    <Style Selector="Button:pointerover">
+                        <Setter Property="Background" Value="#3b3b3b"/>
+                    </Style>
+                    <Style Selector="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActivePanel}" Value="{x:Static vm:ActivePanel.Outline}">
+                                <Setter Property="Background" Value="#555555"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Styles>
+            </Button>
+            <Button Content="Character Bible" Tag="CharacterBible" Click="Button_Click">
+                <Button.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="Background" Value="#2b2b2b"/>
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                        <Setter Property="Margin" Value="2"/>
+                    </Style>
+                    <Style Selector="Button:pointerover">
+                        <Setter Property="Background" Value="#3b3b3b"/>
+                    </Style>
+                    <Style Selector="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActivePanel}" Value="{x:Static vm:ActivePanel.CharacterBible}">
+                                <Setter Property="Background" Value="#555555"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Styles>
+            </Button>
+            <Button Content="Location Bible" Tag="LocationBible" Click="Button_Click">
+                <Button.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="Background" Value="#2b2b2b"/>
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                        <Setter Property="Margin" Value="2"/>
+                    </Style>
+                    <Style Selector="Button:pointerover">
+                        <Setter Property="Background" Value="#3b3b3b"/>
+                    </Style>
+                    <Style Selector="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActivePanel}" Value="{x:Static vm:ActivePanel.LocationBible}">
+                                <Setter Property="Background" Value="#555555"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Styles>
+            </Button>
+            <Button Content="Item Bible" Tag="ItemBible" Click="Button_Click">
+                <Button.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="Background" Value="#2b2b2b"/>
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                        <Setter Property="Margin" Value="2"/>
+                    </Style>
+                    <Style Selector="Button:pointerover">
+                        <Setter Property="Background" Value="#3b3b3b"/>
+                    </Style>
+                    <Style Selector="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActivePanel}" Value="{x:Static vm:ActivePanel.ItemBible}">
+                                <Setter Property="Background" Value="#555555"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Styles>
+            </Button>
+            <Button Content="Lore Bible" Tag="LoreBible" Click="Button_Click">
+                <Button.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="Background" Value="#2b2b2b"/>
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                        <Setter Property="Margin" Value="2"/>
+                    </Style>
+                    <Style Selector="Button:pointerover">
+                        <Setter Property="Background" Value="#3b3b3b"/>
+                    </Style>
+                    <Style Selector="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActivePanel}" Value="{x:Static vm:ActivePanel.LoreBible}">
+                                <Setter Property="Background" Value="#555555"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Styles>
+            </Button>
+        </StackPanel>
+    </Border>
 </UserControl>

--- a/menus/side/SideMenu.axaml.cs
+++ b/menus/side/SideMenu.axaml.cs
@@ -1,4 +1,7 @@
+using System;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TheWordForge;
 
 namespace TheWordForge.menus.side;
 
@@ -7,5 +10,14 @@ public partial class SideMenu : UserControl
     public SideMenu()
     {
         InitializeComponent();
+    }
+
+    private void Button_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is MainViewModel vm && sender is Button btn && btn.Tag is string tag &&
+            Enum.TryParse<ActivePanel>(tag, out var panel))
+        {
+            vm.ActivePanel = panel;
+        }
     }
 }

--- a/menus/top/CharacterBibleTopMenu.axaml
+++ b/menus/top/CharacterBibleTopMenu.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.menus.top.CharacterBibleTopMenu">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Top Menu Placeholder for Character Bible" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/menus/top/CharacterBibleTopMenu.axaml.cs
+++ b/menus/top/CharacterBibleTopMenu.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.menus.top;
+
+public partial class CharacterBibleTopMenu : UserControl
+{
+    public CharacterBibleTopMenu()
+    {
+        InitializeComponent();
+    }
+}

--- a/menus/top/ItemBibleTopMenu.axaml
+++ b/menus/top/ItemBibleTopMenu.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.menus.top.ItemBibleTopMenu">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Top Menu Placeholder for Item Bible" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/menus/top/ItemBibleTopMenu.axaml.cs
+++ b/menus/top/ItemBibleTopMenu.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.menus.top;
+
+public partial class ItemBibleTopMenu : UserControl
+{
+    public ItemBibleTopMenu()
+    {
+        InitializeComponent();
+    }
+}

--- a/menus/top/LocationBibleTopMenu.axaml
+++ b/menus/top/LocationBibleTopMenu.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.menus.top.LocationBibleTopMenu">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Top Menu Placeholder for Location Bible" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/menus/top/LocationBibleTopMenu.axaml.cs
+++ b/menus/top/LocationBibleTopMenu.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.menus.top;
+
+public partial class LocationBibleTopMenu : UserControl
+{
+    public LocationBibleTopMenu()
+    {
+        InitializeComponent();
+    }
+}

--- a/menus/top/LoreBibleTopMenu.axaml
+++ b/menus/top/LoreBibleTopMenu.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.menus.top.LoreBibleTopMenu">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Top Menu Placeholder for Lore Bible" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/menus/top/LoreBibleTopMenu.axaml.cs
+++ b/menus/top/LoreBibleTopMenu.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.menus.top;
+
+public partial class LoreBibleTopMenu : UserControl
+{
+    public LoreBibleTopMenu()
+    {
+        InitializeComponent();
+    }
+}

--- a/menus/top/OutlineTopMenu.axaml
+++ b/menus/top/OutlineTopMenu.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.menus.top.OutlineTopMenu">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Top Menu Placeholder for Outline" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/menus/top/OutlineTopMenu.axaml.cs
+++ b/menus/top/OutlineTopMenu.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.menus.top;
+
+public partial class OutlineTopMenu : UserControl
+{
+    public OutlineTopMenu()
+    {
+        InitializeComponent();
+    }
+}

--- a/menus/top/TimelineTopMenu.axaml
+++ b/menus/top/TimelineTopMenu.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.menus.top.TimelineTopMenu">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Top Menu Placeholder for Timeline" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/menus/top/TimelineTopMenu.axaml.cs
+++ b/menus/top/TimelineTopMenu.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.menus.top;
+
+public partial class TimelineTopMenu : UserControl
+{
+    public TimelineTopMenu()
+    {
+        InitializeComponent();
+    }
+}

--- a/menus/top/TranscriptTopMenu.axaml
+++ b/menus/top/TranscriptTopMenu.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.menus.top.TranscriptTopMenu">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Top Menu Placeholder for Transcript" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/menus/top/TranscriptTopMenu.axaml.cs
+++ b/menus/top/TranscriptTopMenu.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.menus.top;
+
+public partial class TranscriptTopMenu : UserControl
+{
+    public TranscriptTopMenu()
+    {
+        InitializeComponent();
+    }
+}

--- a/panels/CharacterBiblePanel.axaml
+++ b/panels/CharacterBiblePanel.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.panels.CharacterBiblePanel">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Character Bible Panel Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/panels/CharacterBiblePanel.axaml.cs
+++ b/panels/CharacterBiblePanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panels;
+
+public partial class CharacterBiblePanel : UserControl
+{
+    public CharacterBiblePanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/panels/ItemBiblePanel.axaml
+++ b/panels/ItemBiblePanel.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.panels.ItemBiblePanel">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Item Bible Panel Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/panels/ItemBiblePanel.axaml.cs
+++ b/panels/ItemBiblePanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panels;
+
+public partial class ItemBiblePanel : UserControl
+{
+    public ItemBiblePanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/panels/LocationBiblePanel.axaml
+++ b/panels/LocationBiblePanel.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.panels.LocationBiblePanel">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Location Bible Panel Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/panels/LocationBiblePanel.axaml.cs
+++ b/panels/LocationBiblePanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panels;
+
+public partial class LocationBiblePanel : UserControl
+{
+    public LocationBiblePanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/panels/LoreBiblePanel.axaml
+++ b/panels/LoreBiblePanel.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.panels.LoreBiblePanel">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Lore Bible Panel Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/panels/LoreBiblePanel.axaml.cs
+++ b/panels/LoreBiblePanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panels;
+
+public partial class LoreBiblePanel : UserControl
+{
+    public LoreBiblePanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/panels/OutlinePanel.axaml
+++ b/panels/OutlinePanel.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.panels.OutlinePanel">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Outline Panel Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/panels/OutlinePanel.axaml.cs
+++ b/panels/OutlinePanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panels;
+
+public partial class OutlinePanel : UserControl
+{
+    public OutlinePanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/panels/TimelinePanel.axaml
+++ b/panels/TimelinePanel.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.panels.TimelinePanel">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Timeline Panel Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/panels/TimelinePanel.axaml.cs
+++ b/panels/TimelinePanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panels;
+
+public partial class TimelinePanel : UserControl
+{
+    public TimelinePanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/panels/TranscriptPanel.axaml
+++ b/panels/TranscriptPanel.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="TheWordForge.panes.RightPane">
+             x:Class="TheWordForge.panels.TranscriptPanel">
     <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
-        <TextBlock Text="Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+        <TextBlock Text="Transcript Panel Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
     </Border>
 </UserControl>

--- a/panels/TranscriptPanel.axaml.cs
+++ b/panels/TranscriptPanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panels;
+
+public partial class TranscriptPanel : UserControl
+{
+    public TranscriptPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/viewmodels/MainViewModel.cs
+++ b/viewmodels/MainViewModel.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using Avalonia.Controls;
+using TheWordForge.menus.top;
+using TheWordForge.panels;
+
+namespace TheWordForge;
+
+public enum ActivePanel
+{
+    Transcript,
+    Timeline,
+    Outline,
+    CharacterBible,
+    LocationBible,
+    ItemBible,
+    LoreBible
+}
+
+public class MainViewModel : INotifyPropertyChanged
+{
+    private ActivePanel _activePanel;
+    private UserControl _currentCenterPanel = new TranscriptPanel();
+    private UserControl _currentTopMenu = new TranscriptTopMenu();
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public ActivePanel ActivePanel
+    {
+        get => _activePanel;
+        set
+        {
+            if (_activePanel != value)
+            {
+                _activePanel = value;
+                UpdatePanels();
+                OnPropertyChanged(nameof(ActivePanel));
+            }
+        }
+    }
+
+    public UserControl CurrentCenterPanel
+    {
+        get => _currentCenterPanel;
+        private set
+        {
+            if (_currentCenterPanel != value)
+            {
+                _currentCenterPanel = value;
+                OnPropertyChanged(nameof(CurrentCenterPanel));
+            }
+        }
+    }
+
+    public UserControl CurrentTopMenu
+    {
+        get => _currentTopMenu;
+        private set
+        {
+            if (_currentTopMenu != value)
+            {
+                _currentTopMenu = value;
+                OnPropertyChanged(nameof(CurrentTopMenu));
+            }
+        }
+    }
+
+    public MainViewModel()
+    {
+        _activePanel = ActivePanel.Transcript;
+    }
+
+    private void UpdatePanels()
+    {
+        switch (_activePanel)
+        {
+            case ActivePanel.Transcript:
+                CurrentCenterPanel = new TranscriptPanel();
+                CurrentTopMenu = new TranscriptTopMenu();
+                break;
+            case ActivePanel.Timeline:
+                CurrentCenterPanel = new TimelinePanel();
+                CurrentTopMenu = new TimelineTopMenu();
+                break;
+            case ActivePanel.Outline:
+                CurrentCenterPanel = new OutlinePanel();
+                CurrentTopMenu = new OutlineTopMenu();
+                break;
+            case ActivePanel.CharacterBible:
+                CurrentCenterPanel = new CharacterBiblePanel();
+                CurrentTopMenu = new CharacterBibleTopMenu();
+                break;
+            case ActivePanel.LocationBible:
+                CurrentCenterPanel = new LocationBiblePanel();
+                CurrentTopMenu = new LocationBibleTopMenu();
+                break;
+            case ActivePanel.ItemBible:
+                CurrentCenterPanel = new ItemBiblePanel();
+                CurrentTopMenu = new ItemBibleTopMenu();
+                break;
+            case ActivePanel.LoreBible:
+                CurrentCenterPanel = new LoreBiblePanel();
+                CurrentTopMenu = new LoreBibleTopMenu();
+                break;
+        }
+    }
+
+    private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}


### PR DESCRIPTION
## Summary
- Replace SideMenu placeholder with dark-themed vertical buttons for Transcript, Timeline, Outline, and various Bible panels.
- Add placeholder center panels and top menus for each section, each framed by a white border.
- Introduce MainViewModel to switch ActivePanel and wire MainWindow to swap center/top content.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a79cb658ac83309f0806f49be58f68