### PR TITLE
0.0.05 – Menu Layout Adjustments

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -7,13 +7,18 @@
         xmlns:panes="clr-namespace:TheWordForge.panes"
         Title="TheWordForge"
         Width="1280" Height="720">
-    <Grid RowDefinitions="Auto,*,Auto">
-        <ContentControl Grid.Row="0" Content="{Binding CurrentTopMenu}"/>
-        <Grid Grid.Row="1" ColumnDefinitions="15*,60*,25*">
+    <Grid RowDefinitions="100,*,60">
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,*">
+            <Button Width="50" Height="50" Background="Transparent" BorderBrush="Transparent">
+                <Image Source="/resources/icons/hamburger.png" Stretch="Uniform"/>
+            </Button>
+            <ContentControl Grid.Column="1" Content="{Binding CurrentTopMenu}"/>
+        </Grid>
+        <Grid Grid.Row="1" ColumnDefinitions="220,*,220">
             <menusSide:SideMenu Grid.Column="0"/>
             <ContentControl Grid.Column="1" Content="{Binding CurrentCenterPanel}"/>
             <panes:RightPane Grid.Column="2"/>
         </Grid>
-        <panels:StatusBar Grid.Row="2"/>
+        <panels:StatusBar Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
     </Grid>
 </Window>

--- a/menus/side/SideMenu.axaml
+++ b/menus/side/SideMenu.axaml
@@ -42,58 +42,65 @@
                     </Style>
                 </Button.Styles>
             </Button>
-            <Button Content="Character Bible" Tag="CharacterBible" Click="Button_Click">
-                <Button.Styles>
-                    <Style Selector="Button">
-                        <Setter Property="Background" Value="#2b2b2b"/>
-                        <Setter Property="Foreground" Value="White"/>
-                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                        <Setter Property="Margin" Value="2"/>
-                    </Style>
-                    <Style Selector="Button:pointerover">
-                        <Setter Property="Background" Value="#3b3b3b"/>
-                    </Style>
-                </Button.Styles>
-            </Button>
-            <Button Content="Location Bible" Tag="LocationBible" Click="Button_Click">
-                <Button.Styles>
-                    <Style Selector="Button">
-                        <Setter Property="Background" Value="#2b2b2b"/>
-                        <Setter Property="Foreground" Value="White"/>
-                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                        <Setter Property="Margin" Value="2"/>
-                    </Style>
-                    <Style Selector="Button:pointerover">
-                        <Setter Property="Background" Value="#3b3b3b"/>
-                    </Style>
-                </Button.Styles>
-            </Button>
-            <Button Content="Item Bible" Tag="ItemBible" Click="Button_Click">
-                <Button.Styles>
-                    <Style Selector="Button">
-                        <Setter Property="Background" Value="#2b2b2b"/>
-                        <Setter Property="Foreground" Value="White"/>
-                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                        <Setter Property="Margin" Value="2"/>
-                    </Style>
-                    <Style Selector="Button:pointerover">
-                        <Setter Property="Background" Value="#3b3b3b"/>
-                    </Style>
-                </Button.Styles>
-            </Button>
-            <Button Content="Lore Bible" Tag="LoreBible" Click="Button_Click">
-                <Button.Styles>
-                    <Style Selector="Button">
-                        <Setter Property="Background" Value="#2b2b2b"/>
-                        <Setter Property="Foreground" Value="White"/>
-                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                        <Setter Property="Margin" Value="2"/>
-                    </Style>
-                    <Style Selector="Button:pointerover">
-                        <Setter Property="Background" Value="#3b3b3b"/>
-                    </Style>
-                </Button.Styles>
-            </Button>
+
+            <!-- Bible buttons group -->
+            <Border BorderBrush="White" BorderThickness="1" Margin="0,10,0,0" Padding="5">
+                <StackPanel>
+                    <TextBlock Text="Bibles" Foreground="White" Margin="2" HorizontalAlignment="Center" FontStyle="Italic"/>
+                    <Button Content="Character" Tag="CharacterBible" Click="Button_Click">
+                        <Button.Styles>
+                            <Style Selector="Button">
+                                <Setter Property="Background" Value="#2b2b2b"/>
+                                <Setter Property="Foreground" Value="White"/>
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                <Setter Property="Margin" Value="2"/>
+                            </Style>
+                            <Style Selector="Button:pointerover">
+                                <Setter Property="Background" Value="#3b3b3b"/>
+                            </Style>
+                        </Button.Styles>
+                    </Button>
+                    <Button Content="Location" Tag="LocationBible" Click="Button_Click">
+                        <Button.Styles>
+                            <Style Selector="Button">
+                                <Setter Property="Background" Value="#2b2b2b"/>
+                                <Setter Property="Foreground" Value="White"/>
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                <Setter Property="Margin" Value="2"/>
+                            </Style>
+                            <Style Selector="Button:pointerover">
+                                <Setter Property="Background" Value="#3b3b3b"/>
+                            </Style>
+                        </Button.Styles>
+                    </Button>
+                    <Button Content="Items" Tag="ItemBible" Click="Button_Click">
+                        <Button.Styles>
+                            <Style Selector="Button">
+                                <Setter Property="Background" Value="#2b2b2b"/>
+                                <Setter Property="Foreground" Value="White"/>
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                <Setter Property="Margin" Value="2"/>
+                            </Style>
+                            <Style Selector="Button:pointerover">
+                                <Setter Property="Background" Value="#3b3b3b"/>
+                            </Style>
+                        </Button.Styles>
+                    </Button>
+                    <Button Content="Lore" Tag="LoreBible" Click="Button_Click">
+                        <Button.Styles>
+                            <Style Selector="Button">
+                                <Setter Property="Background" Value="#2b2b2b"/>
+                                <Setter Property="Foreground" Value="White"/>
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                <Setter Property="Margin" Value="2"/>
+                            </Style>
+                            <Style Selector="Button:pointerover">
+                                <Setter Property="Background" Value="#3b3b3b"/>
+                            </Style>
+                        </Button.Styles>
+                    </Button>
+                </StackPanel>
+            </Border>
         </StackPanel>
     </Border>
 </UserControl>


### PR DESCRIPTION
## Summary
- Group Bible buttons under a bordered section with header and consistent styling.
- Introduce a 50x50 hamburger menu and expand top row for future ribbon controls.
- Resize side and right panes and heighten status bar for better layout balance.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a97a5cec8330924933de046409a0