### PR TITLE
0.0.06 – Transition System with Preferences Window

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -9,14 +9,19 @@
         Width="1280" Height="720">
     <Grid RowDefinitions="100,*,60">
         <Grid Grid.Row="0" ColumnDefinitions="Auto,*">
-            <Button Width="50" Height="50" Background="Transparent" BorderBrush="Transparent">
+            <Button Name="HamburgerButton" Width="50" Height="50" Background="Transparent" BorderBrush="Transparent">
+                <Button.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Preferences" Click="OpenPreferences"/>
+                    </ContextMenu>
+                </Button.ContextMenu>
                 <Image Source="/resources/icons/hamburger.png" Stretch="Uniform"/>
             </Button>
-            <ContentControl Grid.Column="1" Content="{Binding CurrentTopMenu}"/>
+            <TransitioningContentControl x:Name="TopMenuContent" Grid.Column="1" Content="{Binding CurrentTopMenu}"/>
         </Grid>
         <Grid Grid.Row="1" ColumnDefinitions="220,*,220">
-            <menusSide:SideMenu Grid.Column="0"/>
-            <ContentControl Grid.Column="1" Content="{Binding CurrentCenterPanel}"/>
+            <TransitioningContentControl x:Name="LeftPaneContent" Grid.Column="0" Content="{Binding CurrentLeftPane}"/>
+            <TransitioningContentControl x:Name="CenterPanelContent" Grid.Column="1" Content="{Binding CurrentCenterPanel}"/>
             <panes:RightPane Grid.Column="2"/>
         </Grid>
         <panels:StatusBar Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TheWordForge.services;
 
 namespace TheWordForge;
 
@@ -8,5 +10,20 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         DataContext = new MainViewModel();
+        PreferencesService.TransitionChanged += (_, __) => ApplyTransitions();
+        ApplyTransitions();
+    }
+
+    private void ApplyTransitions()
+    {
+        TopMenuContent.PageTransition = PreferencesService.BuildTransitionFor(TransitionRegion.Top);
+        LeftPaneContent.PageTransition = PreferencesService.BuildTransitionFor(TransitionRegion.Left);
+        CenterPanelContent.PageTransition = PreferencesService.BuildTransitionFor(TransitionRegion.Center);
+    }
+
+    private void OpenPreferences(object? sender, RoutedEventArgs e)
+    {
+        var win = new PreferencesWindow();
+        win.ShowDialog(this);
     }
 }

--- a/PreferencesWindow.axaml
+++ b/PreferencesWindow.axaml
@@ -1,0 +1,13 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        x:Class="TheWordForge.PreferencesWindow"
+        Width="300" Height="150"
+        Title="Preferences">
+    <StackPanel Margin="10">
+        <TextBlock Text="Transitions" Margin="0,0,0,5"/>
+        <ComboBox Items="{Binding TransitionModes}" SelectedItem="{Binding TransitionMode}"/>
+    </StackPanel>
+</Window>

--- a/PreferencesWindow.axaml.cs
+++ b/PreferencesWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace TheWordForge;
+
+public partial class PreferencesWindow : Window
+{
+    public PreferencesWindow()
+    {
+        InitializeComponent();
+        DataContext = new PreferencesViewModel();
+    }
+}

--- a/TheWordForge.csproj
+++ b/TheWordForge.csproj
@@ -31,6 +31,7 @@
     <AvaloniaXaml Update="panels/CenterPanel.axaml" />
     <AvaloniaXaml Update="panels/StatusBar.axaml" />
     <AvaloniaXaml Update="panes/RightPane.axaml" />
+    <AvaloniaXaml Update="PreferencesWindow.axaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -54,6 +55,9 @@
     </Compile>
     <Compile Update="panes/RightPane.axaml.cs">
       <DependentUpon>panes/RightPane.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="PreferencesWindow.axaml.cs">
+      <DependentUpon>PreferencesWindow.axaml</DependentUpon>
     </Compile>
   </ItemGroup>
 

--- a/animations/AccordionTransition.cs
+++ b/animations/AccordionTransition.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Animation;
+using Avalonia.Media;
+using Avalonia;
+using Avalonia.VisualTree;
+
+namespace TheWordForge.animations;
+
+public class AccordionTransition : IPageTransition
+{
+    public TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(200);
+    public PageSlide.SlideAxis Orientation { get; set; } = PageSlide.SlideAxis.Vertical;
+
+    public async Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
+    {
+        var property = Orientation == PageSlide.SlideAxis.Horizontal ? ScaleTransform.ScaleXProperty : ScaleTransform.ScaleYProperty;
+
+        if (from != null)
+        {
+            var scale = new ScaleTransform(1,1);
+            from.RenderTransformOrigin = new RelativePoint(0.5,0.5, RelativeUnit.Relative);
+            from.RenderTransform = scale;
+            var animOut = new Animation
+            {
+                Duration = Duration/2,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, 0d) } }
+                }
+            };
+            await animOut.RunAsync(scale, null, cancellationToken);
+            from.IsVisible = false;
+        }
+
+        if (to != null)
+        {
+            var startValue = Orientation == PageSlide.SlideAxis.Horizontal ? new ScaleTransform(0,1) : new ScaleTransform(1,0);
+            to.RenderTransformOrigin = new RelativePoint(0.5,0.5, RelativeUnit.Relative);
+            to.RenderTransform = startValue;
+            to.IsVisible = true;
+            var animIn = new Animation
+            {
+                Duration = Duration/2,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, 1d) } }
+                }
+            };
+            await animIn.RunAsync(startValue, null, cancellationToken);
+        }
+    }
+}

--- a/animations/PushTransition.cs
+++ b/animations/PushTransition.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Animation;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+
+namespace TheWordForge.animations;
+
+public class PushTransition : IPageTransition
+{
+    public TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(200);
+    public PageSlide.SlideAxis Orientation { get; set; } = PageSlide.SlideAxis.Horizontal;
+
+    public async Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
+        var tasks = new List<Task>();
+        var parent = (from ?? to)!.VisualParent!;
+        var distance = Orientation == PageSlide.SlideAxis.Horizontal ? parent.Bounds.Width : parent.Bounds.Height;
+        var property = Orientation == PageSlide.SlideAxis.Horizontal ? TranslateTransform.XProperty : TranslateTransform.YProperty;
+
+        if (from != null)
+        {
+            var anim = new Animation
+            {
+                Duration = Duration,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(0), Setters = { new Setter(property, 0d) } },
+                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, forward ? distance : -distance) } }
+                }
+            };
+            tasks.Add(anim.RunAsync(from, null, cancellationToken));
+        }
+
+        if (to != null)
+        {
+            to.IsVisible = true;
+            var anim = new Animation
+            {
+                Duration = Duration,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(0), Setters = { new Setter(property, forward ? -distance : distance) } },
+                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, 0d) } }
+                }
+            };
+            tasks.Add(anim.RunAsync(to, null, cancellationToken));
+        }
+
+        await Task.WhenAll(tasks);
+
+        if (from != null && !cancellationToken.IsCancellationRequested)
+            from.IsVisible = false;
+    }
+}

--- a/services/PreferencesService.cs
+++ b/services/PreferencesService.cs
@@ -1,0 +1,61 @@
+using System;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia;
+using TheWordForge.animations;
+
+namespace TheWordForge.services;
+
+public enum TransitionMode
+{
+    Off,
+    Slide,
+    Fade,
+    Push,
+    Accordion
+}
+
+public enum TransitionRegion
+{
+    Top,
+    Left,
+    Center
+}
+
+public static class PreferencesService
+{
+    private static TransitionMode _transition = TransitionMode.Off;
+
+    public static TransitionMode Transition
+    {
+        get => _transition;
+        set
+        {
+            if (_transition != value)
+            {
+                _transition = value;
+                TransitionChanged?.Invoke(null, EventArgs.Empty);
+            }
+        }
+    }
+
+    public static event EventHandler? TransitionChanged;
+
+    public static IPageTransition? BuildTransitionFor(TransitionRegion region)
+    {
+        var axis = region switch
+        {
+            TransitionRegion.Top => PageSlide.SlideAxis.Vertical,
+            _ => PageSlide.SlideAxis.Horizontal
+        };
+
+        return Transition switch
+        {
+            TransitionMode.Slide => new PageSlide(TimeSpan.FromMilliseconds(200), axis),
+            TransitionMode.Fade => new CrossFade(TimeSpan.FromMilliseconds(200)),
+            TransitionMode.Push => new PushTransition { Duration = TimeSpan.FromMilliseconds(200), Orientation = axis },
+            TransitionMode.Accordion => new AccordionTransition { Duration = TimeSpan.FromMilliseconds(200), Orientation = axis },
+            _ => null
+        };
+    }
+}

--- a/viewmodels/MainViewModel.cs
+++ b/viewmodels/MainViewModel.cs
@@ -21,6 +21,7 @@ public class MainViewModel : INotifyPropertyChanged
     private ActivePanel _activePanel;
     private UserControl _currentCenterPanel = new TranscriptPanel();
     private UserControl _currentTopMenu = new TranscriptTopMenu();
+    private UserControl _currentLeftPane = new menus.side.SideMenu();
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -64,6 +65,19 @@ public class MainViewModel : INotifyPropertyChanged
         }
     }
 
+    public UserControl CurrentLeftPane
+    {
+        get => _currentLeftPane;
+        private set
+        {
+            if (_currentLeftPane != value)
+            {
+                _currentLeftPane = value;
+                OnPropertyChanged(nameof(CurrentLeftPane));
+            }
+        }
+    }
+
     public MainViewModel()
     {
         _activePanel = ActivePanel.Transcript;
@@ -76,30 +90,37 @@ public class MainViewModel : INotifyPropertyChanged
             case ActivePanel.Transcript:
                 CurrentCenterPanel = new TranscriptPanel();
                 CurrentTopMenu = new TranscriptTopMenu();
+                CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.Timeline:
                 CurrentCenterPanel = new TimelinePanel();
                 CurrentTopMenu = new TimelineTopMenu();
+                CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.Outline:
                 CurrentCenterPanel = new OutlinePanel();
                 CurrentTopMenu = new OutlineTopMenu();
+                CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.CharacterBible:
                 CurrentCenterPanel = new CharacterBiblePanel();
                 CurrentTopMenu = new CharacterBibleTopMenu();
+                CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.LocationBible:
                 CurrentCenterPanel = new LocationBiblePanel();
                 CurrentTopMenu = new LocationBibleTopMenu();
+                CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.ItemBible:
                 CurrentCenterPanel = new ItemBiblePanel();
                 CurrentTopMenu = new ItemBibleTopMenu();
+                CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.LoreBible:
                 CurrentCenterPanel = new LoreBiblePanel();
                 CurrentTopMenu = new LoreBibleTopMenu();
+                CurrentLeftPane = new menus.side.SideMenu();
                 break;
         }
     }

--- a/viewmodels/PreferencesViewModel.cs
+++ b/viewmodels/PreferencesViewModel.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel;
+using TheWordForge.services;
+
+namespace TheWordForge;
+
+public class PreferencesViewModel : INotifyPropertyChanged
+{
+    public Array TransitionModes => Enum.GetValues(typeof(TransitionMode));
+
+    public TransitionMode TransitionMode
+    {
+        get => PreferencesService.Transition;
+        set
+        {
+            if (PreferencesService.Transition != value)
+            {
+                PreferencesService.Transition = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TransitionMode)));
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}


### PR DESCRIPTION
## Summary
- add a Preferences window with a dropdown to select global transition mode
- wire hamburger menu to open Preferences and use TransitioningContentControl with custom transitions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b0544224833081436d1d1e252bcd