### PR TITLE
0.0.08 – Expanded Hamburger Menu and Transition Options

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -9,10 +9,21 @@
         Width="1280" Height="720">
     <Grid RowDefinitions="100,*,60">
         <Grid Grid.Row="0" ColumnDefinitions="Auto,*">
-            <Button Name="HamburgerButton" Width="50" Height="50" Background="Transparent" BorderBrush="Transparent">
+            <Button Name="HamburgerButton" Width="50" Height="50" Background="Transparent" BorderBrush="Transparent" Click="OpenHamburgerMenu">
                 <Button.ContextMenu>
                     <ContextMenu>
+                        <MenuItem Header="New Project"/>
+                        <MenuItem Header="Load Project"/>
+                        <MenuItem Header="Save Project"/>
                         <MenuItem Header="Preferences" Click="OpenPreferences"/>
+                        <MenuItem Header="Export">
+                            <MenuItem Header="PDF"/>
+                            <MenuItem Header="DOCX"/>
+                            <MenuItem Header="RTF"/>
+                            <MenuItem Header="TXT"/>
+                        </MenuItem>
+                        <MenuItem Header="Print"/>
+                        <MenuItem Header="Exit" Click="ExitApplication"/>
                     </ContextMenu>
                 </Button.ContextMenu>
                 <Image Source="/resources/icons/hamburger.png" Stretch="Uniform"/>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -26,4 +26,18 @@ public partial class MainWindow : Window
         var win = new PreferencesWindow();
         win.ShowDialog(this);
     }
+
+    private void OpenHamburgerMenu(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.ContextMenu is { } menu)
+        {
+            menu.PlacementTarget = button;
+            menu.Open();
+        }
+    }
+
+    private void ExitApplication(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
 }

--- a/PreferencesWindow.axaml
+++ b/PreferencesWindow.axaml
@@ -9,5 +9,8 @@
     <StackPanel Margin="10">
         <TextBlock Text="Transitions" Margin="0,0,0,5"/>
         <ComboBox ItemsSource="{Binding TransitionModes}" SelectedItem="{Binding TransitionMode}"/>
+        <TextBlock Text="Speed" Margin="0,10,0,5"/>
+        <ComboBox ItemsSource="{Binding TransitionSpeeds}" SelectedItem="{Binding TransitionSpeed}"/>
+        <Button Content="OK" HorizontalAlignment="Right" Margin="0,10,0,0" Click="ClosePreferences"/>
     </StackPanel>
 </Window>

--- a/PreferencesWindow.axaml.cs
+++ b/PreferencesWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace TheWordForge;
 
@@ -8,5 +9,10 @@ public partial class PreferencesWindow : Window
     {
         InitializeComponent();
         DataContext = new PreferencesViewModel();
+    }
+
+    private void ClosePreferences(object? sender, RoutedEventArgs e)
+    {
+        Close();
     }
 }

--- a/services/PreferencesService.cs
+++ b/services/PreferencesService.cs
@@ -11,8 +11,13 @@ public enum TransitionMode
     Off,
     Slide,
     Fade,
-    Push,
-    Accordion
+    Push
+}
+
+public enum TransitionSpeed
+{
+    Fast,
+    Slow
 }
 
 public enum TransitionRegion
@@ -25,6 +30,7 @@ public enum TransitionRegion
 public static class PreferencesService
 {
     private static TransitionMode _transition = TransitionMode.Off;
+    private static TransitionSpeed _speed = TransitionSpeed.Fast;
 
     public static TransitionMode Transition
     {
@@ -34,6 +40,19 @@ public static class PreferencesService
             if (_transition != value)
             {
                 _transition = value;
+                TransitionChanged?.Invoke(null, EventArgs.Empty);
+            }
+        }
+    }
+
+    public static TransitionSpeed Speed
+    {
+        get => _speed;
+        set
+        {
+            if (_speed != value)
+            {
+                _speed = value;
                 TransitionChanged?.Invoke(null, EventArgs.Empty);
             }
         }
@@ -49,12 +68,15 @@ public static class PreferencesService
             _ => PageSlide.SlideAxis.Horizontal
         };
 
+        var duration = Speed == TransitionSpeed.Fast
+            ? TimeSpan.FromMilliseconds(200)
+            : TimeSpan.FromMilliseconds(400);
+
         return Transition switch
         {
-            TransitionMode.Slide => new PageSlide(TimeSpan.FromMilliseconds(200), axis),
-            TransitionMode.Fade => new CrossFade(TimeSpan.FromMilliseconds(200)),
-            TransitionMode.Push => new PushTransition { Duration = TimeSpan.FromMilliseconds(200), Orientation = axis },
-            TransitionMode.Accordion => new AccordionTransition { Duration = TimeSpan.FromMilliseconds(200), Orientation = axis },
+            TransitionMode.Slide => new PageSlide(duration, axis),
+            TransitionMode.Fade => new CrossFade(duration),
+            TransitionMode.Push => new PushTransition { Duration = duration, Orientation = axis },
             _ => null
         };
     }

--- a/viewmodels/PreferencesViewModel.cs
+++ b/viewmodels/PreferencesViewModel.cs
@@ -7,6 +7,7 @@ namespace TheWordForge;
 public class PreferencesViewModel : INotifyPropertyChanged
 {
     public Array TransitionModes => Enum.GetValues(typeof(TransitionMode));
+    public Array TransitionSpeeds => Enum.GetValues(typeof(TransitionSpeed));
 
     public TransitionMode TransitionMode
     {
@@ -17,6 +18,19 @@ public class PreferencesViewModel : INotifyPropertyChanged
             {
                 PreferencesService.Transition = value;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TransitionMode)));
+            }
+        }
+    }
+
+    public TransitionSpeed TransitionSpeed
+    {
+        get => PreferencesService.Speed;
+        set
+        {
+            if (PreferencesService.Speed != value)
+            {
+                PreferencesService.Speed = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TransitionSpeed)));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Expand hamburger menu with project management placeholders, export submenu, and exit option; open via left click.
- Add speed selection and OK action to preferences while removing accordion transition.
- Support transition speed preference across top menu, left pane, and center pane.

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b83d46508330bdfcd3df5434a5e4