### PR TITLE
0.0.09 – Dynamic Transition and Preferences Window Fixes

### DIFF
--- a/PreferencesWindow.axaml
+++ b/PreferencesWindow.axaml
@@ -4,7 +4,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         x:Class="TheWordForge.PreferencesWindow"
-        Width="300" Height="150"
+        MinWidth="300" MinHeight="150" SizeToContent="WidthAndHeight"
         Title="Preferences">
     <StackPanel Margin="10">
         <TextBlock Text="Transitions" Margin="0,0,0,5"/>

--- a/animations/DynamicTransition.cs
+++ b/animations/DynamicTransition.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Avalonia.Styling;
+
+namespace TheWordForge.animations;
+
+public class DynamicTransition : IPageTransition
+{
+    public TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(200);
+
+    public async Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
+    {
+        var property = ScaleTransform.ScaleYProperty;
+
+        if (from != null)
+        {
+            var scale = new ScaleTransform(1, 1);
+            from.RenderTransformOrigin = new RelativePoint(0.5, 0, RelativeUnit.Relative);
+            from.RenderTransform = scale;
+            var animOut = new Animation
+            {
+                Duration = Duration / 2,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, 0d) } }
+                }
+            };
+            await animOut.RunAsync(scale, cancellationToken);
+            from.IsVisible = false;
+        }
+
+        if (to != null)
+        {
+            var start = new ScaleTransform(1, 0);
+            to.RenderTransformOrigin = new RelativePoint(0.5, 0, RelativeUnit.Relative);
+            to.RenderTransform = start;
+            to.IsVisible = true;
+            var animIn = new Animation
+            {
+                Duration = Duration / 2,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, 1d) } }
+                }
+            };
+            await animIn.RunAsync(start, cancellationToken);
+        }
+    }
+}

--- a/services/PreferencesService.cs
+++ b/services/PreferencesService.cs
@@ -11,7 +11,8 @@ public enum TransitionMode
     Off,
     Slide,
     Fade,
-    Push
+    Push,
+    Dynamic
 }
 
 public enum TransitionSpeed
@@ -62,6 +63,9 @@ public static class PreferencesService
 
     public static IPageTransition? BuildTransitionFor(TransitionRegion region)
     {
+        if (region == TransitionRegion.Left)
+            return null;
+
         var axis = region switch
         {
             TransitionRegion.Top => PageSlide.SlideAxis.Vertical,
@@ -77,6 +81,7 @@ public static class PreferencesService
             TransitionMode.Slide => new PageSlide(duration, axis),
             TransitionMode.Fade => new CrossFade(duration),
             TransitionMode.Push => new PushTransition { Duration = duration, Orientation = axis },
+            TransitionMode.Dynamic => new DynamicTransition { Duration = duration },
             _ => null
         };
     }


### PR DESCRIPTION
## Summary
- auto-size Preferences window to keep controls and OK button visible
- add Dynamic transition that retracts then expands panels
- left menu no longer animates on panel changes

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a7bb4dca888330ba72061c6d0f596d