### PR TITLE
0.0.10 – Fix Broken Transitions

### DIFF
--- a/animations/DynamicTransition.cs
+++ b/animations/DynamicTransition.cs
@@ -6,6 +6,7 @@ using Avalonia.Animation;
 using Avalonia.Media;
 using Avalonia.VisualTree;
 using Avalonia.Styling;
+using Avalonia.Input;
 
 namespace TheWordForge.animations;
 
@@ -32,6 +33,9 @@ public class DynamicTransition : IPageTransition
             };
             await animOut.RunAsync(scale, cancellationToken);
             from.IsVisible = false;
+            if (from is InputElement fromElement)
+                fromElement.IsHitTestVisible = false;
+            from.RenderTransform = null;
         }
 
         if (to != null)
@@ -40,6 +44,8 @@ public class DynamicTransition : IPageTransition
             to.RenderTransformOrigin = new RelativePoint(0.5, 0, RelativeUnit.Relative);
             to.RenderTransform = start;
             to.IsVisible = true;
+            if (to is InputElement toElement)
+                toElement.IsHitTestVisible = true;
             var animIn = new Animation
             {
                 Duration = Duration / 2,
@@ -49,6 +55,7 @@ public class DynamicTransition : IPageTransition
                 }
             };
             await animIn.RunAsync(start, cancellationToken);
+            to.RenderTransform = null;
         }
     }
 }

--- a/animations/SlideTransition.cs
+++ b/animations/SlideTransition.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
@@ -11,7 +10,7 @@ using Avalonia.Input;
 
 namespace TheWordForge.animations;
 
-public class PushTransition : IPageTransition
+public class SlideTransition : IPageTransition
 {
     public TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(200);
     public PageSlide.SlideAxis Orientation { get; set; } = PageSlide.SlideAxis.Horizontal;
@@ -21,50 +20,24 @@ public class PushTransition : IPageTransition
         if (cancellationToken.IsCancellationRequested)
             return;
 
-        var tasks = new List<Task>();
         var parent = ((from ?? to)!).GetVisualParent()!;
         var distance = Orientation == PageSlide.SlideAxis.Horizontal ? parent.Bounds.Width : parent.Bounds.Height;
         var property = Orientation == PageSlide.SlideAxis.Horizontal ? TranslateTransform.XProperty : TranslateTransform.YProperty;
 
         if (from != null)
         {
-            var transform = new TranslateTransform();
-            from.RenderTransform = transform;
-            var anim = new Animation
+            var fromTransform = new TranslateTransform();
+            from.RenderTransform = fromTransform;
+            var animOut = new Animation
             {
                 Duration = Duration,
                 Children =
                 {
                     new KeyFrame { Cue = new Cue(0), Setters = { new Setter(property, 0d) } },
-                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, forward ? distance : -distance) } }
+                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, forward ? -distance : distance) } }
                 }
             };
-            tasks.Add(anim.RunAsync(transform, cancellationToken));
-        }
-
-        if (to != null)
-        {
-            var transform = new TranslateTransform();
-            to.RenderTransform = transform;
-            to.IsVisible = true;
-            if (to is InputElement toElement)
-                toElement.IsHitTestVisible = true;
-            var anim = new Animation
-            {
-                Duration = Duration,
-                Children =
-                {
-                    new KeyFrame { Cue = new Cue(0), Setters = { new Setter(property, forward ? -distance : distance) } },
-                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, 0d) } }
-                }
-            };
-            tasks.Add(anim.RunAsync(transform, cancellationToken));
-        }
-
-        await Task.WhenAll(tasks);
-
-        if (from != null && !cancellationToken.IsCancellationRequested)
-        {
+            await animOut.RunAsync(fromTransform, cancellationToken);
             from.IsVisible = false;
             if (from is InputElement fromElement)
                 fromElement.IsHitTestVisible = false;
@@ -72,6 +45,23 @@ public class PushTransition : IPageTransition
         }
 
         if (to != null)
+        {
+            var toTransform = new TranslateTransform();
+            to.RenderTransform = toTransform;
+            to.IsVisible = true;
+            if (to is InputElement toElement)
+                toElement.IsHitTestVisible = true;
+            var animIn = new Animation
+            {
+                Duration = Duration,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(0), Setters = { new Setter(property, forward ? distance : -distance) } },
+                    new KeyFrame { Cue = new Cue(1), Setters = { new Setter(property, 0d) } }
+                }
+            };
+            await animIn.RunAsync(toTransform, cancellationToken);
             to.RenderTransform = null;
+        }
     }
 }

--- a/services/PreferencesService.cs
+++ b/services/PreferencesService.cs
@@ -78,7 +78,7 @@ public static class PreferencesService
 
         return Transition switch
         {
-            TransitionMode.Slide => new PageSlide(duration, axis),
+            TransitionMode.Slide => new SlideTransition { Duration = duration, Orientation = axis },
             TransitionMode.Fade => new CrossFade(duration),
             TransitionMode.Push => new PushTransition { Duration = duration, Orientation = axis },
             TransitionMode.Dynamic => new DynamicTransition { Duration = duration },


### PR DESCRIPTION
## Summary
- add slide, push, and dynamic transition fixes that clean up transforms and hit testing
- introduce SlideTransition and wire preference service to use custom transitions

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68a7be0d61e48330b074f6cdabe7857d