### PR TITLE
0.0.13 – Top Menu with Right Pane Controls and Customize Windows

### DIFF
--- a/CustomizationWindow.axaml
+++ b/CustomizationWindow.axaml
@@ -1,0 +1,7 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="TheWordForge.CustomizationWindow"
+        MinWidth="300" MinHeight="150" SizeToContent="WidthAndHeight">
+    <TextBlock x:Name="TitleBlock" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+</Window>
+

--- a/CustomizationWindow.axaml.cs
+++ b/CustomizationWindow.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+
+namespace TheWordForge;
+
+public partial class CustomizationWindow : Window
+{
+    public CustomizationWindow() : this("Customization")
+    {
+    }
+
+    public CustomizationWindow(string title)
+    {
+        InitializeComponent();
+        Title = title;
+        TitleBlock.Text = title;
+    }
+}
+

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -4,7 +4,6 @@
         xmlns:menusTop="clr-namespace:TheWordForge.menus.top"
         xmlns:menusSide="clr-namespace:TheWordForge.menus.side"
         xmlns:panels="clr-namespace:TheWordForge.panels"
-        xmlns:panes="clr-namespace:TheWordForge.panes"
         Title="TheWordForge"
         Width="1280" Height="720">
     <Grid RowDefinitions="100,*,60">
@@ -33,7 +32,7 @@
         <Grid Grid.Row="1" ColumnDefinitions="220,*,220">
             <TransitioningContentControl x:Name="LeftPaneContent" Grid.Column="0" Content="{Binding CurrentLeftPane}"/>
             <TransitioningContentControl x:Name="CenterPanelContent" Grid.Column="1" Content="{Binding CurrentCenterPanel}"/>
-            <panes:RightPane Grid.Column="2"/>
+            <TransitioningContentControl x:Name="RightPaneContent" Grid.Column="2" Content="{Binding CurrentRightPane}"/>
         </Grid>
         <panels:StatusBar Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
     </Grid>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -19,6 +19,7 @@ public partial class MainWindow : Window
         TopMenuContent.PageTransition = PreferencesService.BuildTransition();
         LeftPaneContent.PageTransition = PreferencesService.BuildTransition();
         CenterPanelContent.PageTransition = PreferencesService.BuildTransition();
+        RightPaneContent.PageTransition = PreferencesService.BuildTransition();
     }
 
     private void OpenPreferences(object? sender, RoutedEventArgs e)

--- a/TheWordForge.csproj
+++ b/TheWordForge.csproj
@@ -31,7 +31,14 @@
     <AvaloniaXaml Update="panels/CenterPanel.axaml" />
     <AvaloniaXaml Update="panels/StatusBar.axaml" />
     <AvaloniaXaml Update="panes/RightPane.axaml" />
+    <AvaloniaXaml Update="panes/TimelineRightPane.axaml" />
+    <AvaloniaXaml Update="panes/OutlineRightPane.axaml" />
+    <AvaloniaXaml Update="panes/CharacterBibleRightPane.axaml" />
+    <AvaloniaXaml Update="panes/LocationBibleRightPane.axaml" />
+    <AvaloniaXaml Update="panes/ItemBibleRightPane.axaml" />
+    <AvaloniaXaml Update="panes/LoreBibleRightPane.axaml" />
     <AvaloniaXaml Update="PreferencesWindow.axaml" />
+    <AvaloniaXaml Update="CustomizationWindow.axaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -56,8 +63,29 @@
     <Compile Update="panes/RightPane.axaml.cs">
       <DependentUpon>panes/RightPane.axaml</DependentUpon>
     </Compile>
+    <Compile Update="panes/TimelineRightPane.axaml.cs">
+      <DependentUpon>panes/TimelineRightPane.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="panes/OutlineRightPane.axaml.cs">
+      <DependentUpon>panes/OutlineRightPane.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="panes/CharacterBibleRightPane.axaml.cs">
+      <DependentUpon>panes/CharacterBibleRightPane.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="panes/LocationBibleRightPane.axaml.cs">
+      <DependentUpon>panes/LocationBibleRightPane.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="panes/ItemBibleRightPane.axaml.cs">
+      <DependentUpon>panes/ItemBibleRightPane.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="panes/LoreBibleRightPane.axaml.cs">
+      <DependentUpon>panes/LoreBibleRightPane.axaml</DependentUpon>
+    </Compile>
     <Compile Update="PreferencesWindow.axaml.cs">
       <DependentUpon>PreferencesWindow.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="CustomizationWindow.axaml.cs">
+      <DependentUpon>CustomizationWindow.axaml</DependentUpon>
     </Compile>
   </ItemGroup>
 

--- a/menus/top/TopMenu.axaml
+++ b/menus/top/TopMenu.axaml
@@ -1,5 +1,28 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="TheWordForge.menus.top.TopMenu">
-    <TextBlock Text="Top Menu Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0">
+        <StackPanel>
+            <TextBlock Text="Right Pane" Foreground="White" HorizontalAlignment="Center"/>
+            <Border BorderBrush="White" BorderThickness="1" Padding="5">
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <Button x:Name="TimelineButton" Content="Timeline" Click="OpenTimeline"/>
+                    <Button x:Name="OutlineButton" Content="Outline" Click="OpenOutline"/>
+                    <StackPanel>
+                        <TextBlock Text="Bibles" Foreground="White" HorizontalAlignment="Center"/>
+                        <Border Background="Gray" Padding="5">
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <Button x:Name="CharacterBibleButton" Content="Character" Click="OpenCharacterBible"/>
+                                <Button x:Name="LocationBibleButton" Content="Location" Click="OpenLocationBible"/>
+                                <Button x:Name="ItemBibleButton" Content="Item" Click="OpenItemBible"/>
+                                <Button x:Name="LoreBibleButton" Content="Lore" Click="OpenLoreBible"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+        <Button x:Name="CustomizeButton" Content="Customize" Margin="10,0,0,0" Click="OpenCustomize"/>
+    </StackPanel>
 </UserControl>
+

--- a/menus/top/TopMenu.axaml.cs
+++ b/menus/top/TopMenu.axaml.cs
@@ -1,11 +1,103 @@
+using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TheWordForge.panes;
+using TheWordForge;
 
 namespace TheWordForge.menus.top;
 
 public partial class TopMenu : UserControl
 {
+    private MainViewModel? ViewModel => DataContext as MainViewModel;
+
     public TopMenu()
     {
         InitializeComponent();
+        DataContextChanged += (_, __) => Attach();
+    }
+
+    private void Attach()
+    {
+        if (ViewModel != null)
+        {
+            ViewModel.PropertyChanged += ViewModelOnPropertyChanged;
+            UpdateState();
+        }
+    }
+
+    private void ViewModelOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(MainViewModel.ActivePanel))
+            UpdateState();
+    }
+
+    private void UpdateState()
+    {
+        if (ViewModel == null) return;
+        var active = ViewModel.ActivePanel;
+        TimelineButton.IsEnabled = active != ActivePanel.Timeline;
+        OutlineButton.IsEnabled = active != ActivePanel.Outline;
+        CharacterBibleButton.IsEnabled = active != ActivePanel.CharacterBible;
+        LocationBibleButton.IsEnabled = active != ActivePanel.LocationBible;
+        ItemBibleButton.IsEnabled = active != ActivePanel.ItemBible;
+        LoreBibleButton.IsEnabled = active != ActivePanel.LoreBible;
+        CustomizeButton.Content = $"Customize {GetPanelName(active)}";
+    }
+
+    private static string GetPanelName(ActivePanel panel) => panel switch
+    {
+        ActivePanel.Transcript => "Transcript",
+        ActivePanel.Timeline => "Timeline",
+        ActivePanel.Outline => "Outline",
+        ActivePanel.CharacterBible => "Character Bible",
+        ActivePanel.LocationBible => "Location Bible",
+        ActivePanel.ItemBible => "Item Bible",
+        ActivePanel.LoreBible => "Lore Bible",
+        _ => panel.ToString()
+    };
+
+    private void OpenTimeline(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel != null)
+            ViewModel.CurrentRightPane = new TimelineRightPane();
+    }
+
+    private void OpenOutline(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel != null)
+            ViewModel.CurrentRightPane = new OutlineRightPane();
+    }
+
+    private void OpenCharacterBible(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel != null)
+            ViewModel.CurrentRightPane = new CharacterBibleRightPane();
+    }
+
+    private void OpenLocationBible(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel != null)
+            ViewModel.CurrentRightPane = new LocationBibleRightPane();
+    }
+
+    private void OpenItemBible(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel != null)
+            ViewModel.CurrentRightPane = new ItemBibleRightPane();
+    }
+
+    private void OpenLoreBible(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel != null)
+            ViewModel.CurrentRightPane = new LoreBibleRightPane();
+    }
+
+    private void OpenCustomize(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel == null) return;
+        var title = $"{GetPanelName(ViewModel.ActivePanel)} Customization";
+        var win = new CustomizationWindow(title);
+        win.Show();
     }
 }
+

--- a/panes/CharacterBibleRightPane.axaml
+++ b/panes/CharacterBibleRightPane.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TheWordForge.panes.CharacterBibleRightPane">
+    <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
+        <TextBlock Text="Character Bible Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+    </Border>
+</UserControl>
+

--- a/panes/CharacterBibleRightPane.axaml.cs
+++ b/panes/CharacterBibleRightPane.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panes;
+
+public partial class CharacterBibleRightPane : UserControl
+{
+    public CharacterBibleRightPane()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/panes/ItemBibleRightPane.axaml
+++ b/panes/ItemBibleRightPane.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TheWordForge.panes.ItemBibleRightPane">
+    <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
+        <TextBlock Text="Item Bible Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+    </Border>
+</UserControl>
+

--- a/panes/ItemBibleRightPane.axaml.cs
+++ b/panes/ItemBibleRightPane.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panes;
+
+public partial class ItemBibleRightPane : UserControl
+{
+    public ItemBibleRightPane()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/panes/LocationBibleRightPane.axaml
+++ b/panes/LocationBibleRightPane.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TheWordForge.panes.LocationBibleRightPane">
+    <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
+        <TextBlock Text="Location Bible Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+    </Border>
+</UserControl>
+

--- a/panes/LocationBibleRightPane.axaml.cs
+++ b/panes/LocationBibleRightPane.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panes;
+
+public partial class LocationBibleRightPane : UserControl
+{
+    public LocationBibleRightPane()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/panes/LoreBibleRightPane.axaml
+++ b/panes/LoreBibleRightPane.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TheWordForge.panes.LoreBibleRightPane">
+    <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
+        <TextBlock Text="Lore Bible Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+    </Border>
+</UserControl>
+

--- a/panes/LoreBibleRightPane.axaml.cs
+++ b/panes/LoreBibleRightPane.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panes;
+
+public partial class LoreBibleRightPane : UserControl
+{
+    public LoreBibleRightPane()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/panes/OutlineRightPane.axaml
+++ b/panes/OutlineRightPane.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TheWordForge.panes.OutlineRightPane">
+    <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
+        <TextBlock Text="Outline Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+    </Border>
+</UserControl>
+

--- a/panes/OutlineRightPane.axaml.cs
+++ b/panes/OutlineRightPane.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panes;
+
+public partial class OutlineRightPane : UserControl
+{
+    public OutlineRightPane()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/panes/TimelineRightPane.axaml
+++ b/panes/TimelineRightPane.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TheWordForge.panes.TimelineRightPane">
+    <Border BorderBrush="White" BorderThickness="1" Background="#1e1e1e">
+        <TextBlock Text="Timeline Right Pane Placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+    </Border>
+</UserControl>
+

--- a/panes/TimelineRightPane.axaml.cs
+++ b/panes/TimelineRightPane.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace TheWordForge.panes;
+
+public partial class TimelineRightPane : UserControl
+{
+    public TimelineRightPane()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/services/PreferencesService.cs
+++ b/services/PreferencesService.cs
@@ -5,7 +5,7 @@ namespace TheWordForge.services;
 
 public static class PreferencesService
 {
-    private static bool _transitionsEnabled;
+    private static bool _transitionsEnabled = true;
 
     public static bool TransitionsEnabled
     {

--- a/viewmodels/MainViewModel.cs
+++ b/viewmodels/MainViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using Avalonia.Controls;
 using TheWordForge.menus.top;
 using TheWordForge.panels;
+using TheWordForge.panes;
 
 namespace TheWordForge;
 
@@ -20,8 +21,9 @@ public class MainViewModel : INotifyPropertyChanged
 {
     private ActivePanel _activePanel;
     private UserControl _currentCenterPanel = new TranscriptPanel();
-    private UserControl _currentTopMenu = new TranscriptTopMenu();
+    private UserControl _currentTopMenu = new TopMenu();
     private UserControl _currentLeftPane = new menus.side.SideMenu();
+    private UserControl _currentRightPane = new RightPane();
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -78,6 +80,19 @@ public class MainViewModel : INotifyPropertyChanged
         }
     }
 
+    public UserControl CurrentRightPane
+    {
+        get => _currentRightPane;
+        set
+        {
+            if (_currentRightPane != value)
+            {
+                _currentRightPane = value;
+                OnPropertyChanged(nameof(CurrentRightPane));
+            }
+        }
+    }
+
     public MainViewModel()
     {
         _activePanel = ActivePanel.Transcript;
@@ -89,37 +104,30 @@ public class MainViewModel : INotifyPropertyChanged
         {
             case ActivePanel.Transcript:
                 CurrentCenterPanel = new TranscriptPanel();
-                CurrentTopMenu = new TranscriptTopMenu();
                 CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.Timeline:
                 CurrentCenterPanel = new TimelinePanel();
-                CurrentTopMenu = new TimelineTopMenu();
                 CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.Outline:
                 CurrentCenterPanel = new OutlinePanel();
-                CurrentTopMenu = new OutlineTopMenu();
                 CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.CharacterBible:
                 CurrentCenterPanel = new CharacterBiblePanel();
-                CurrentTopMenu = new CharacterBibleTopMenu();
                 CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.LocationBible:
                 CurrentCenterPanel = new LocationBiblePanel();
-                CurrentTopMenu = new LocationBibleTopMenu();
                 CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.ItemBible:
                 CurrentCenterPanel = new ItemBiblePanel();
-                CurrentTopMenu = new ItemBibleTopMenu();
                 CurrentLeftPane = new menus.side.SideMenu();
                 break;
             case ActivePanel.LoreBible:
                 CurrentCenterPanel = new LoreBiblePanel();
-                CurrentTopMenu = new LoreBibleTopMenu();
                 CurrentLeftPane = new menus.side.SideMenu();
                 break;
         }


### PR DESCRIPTION
## Summary
- enable transitions by default and apply them to the right pane
- add top menu with right-pane controls and dynamic customize button
- provide placeholder right panes and customization windows

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a7cc6096b0833090e8ac8d80f0c56f