### PR TITLE
0.0.14 – Layout and Styling Adjustments

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -8,7 +8,7 @@
         Width="1280" Height="720">
     <Grid RowDefinitions="100,*,60">
         <Grid Grid.Row="0" ColumnDefinitions="Auto,*">
-            <Button Name="HamburgerButton" Width="50" Height="50" Background="Transparent" BorderBrush="Transparent" Click="OpenHamburgerMenu">
+            <Button Name="HamburgerButton" Width="100" Height="100" Background="Transparent" BorderBrush="Transparent" Click="OpenHamburgerMenu">
                 <Button.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="New Project"/>
@@ -29,7 +29,7 @@
             </Button>
             <TransitioningContentControl x:Name="TopMenuContent" Grid.Column="1" Content="{Binding CurrentTopMenu}"/>
         </Grid>
-        <Grid Grid.Row="1" ColumnDefinitions="220,*,220">
+        <Grid Grid.Row="1" ColumnDefinitions="165,*,330">
             <TransitioningContentControl x:Name="LeftPaneContent" Grid.Column="0" Content="{Binding CurrentLeftPane}"/>
             <TransitioningContentControl x:Name="CenterPanelContent" Grid.Column="1" Content="{Binding CurrentCenterPanel}"/>
             <TransitioningContentControl x:Name="RightPaneContent" Grid.Column="2" Content="{Binding CurrentRightPane}"/>

--- a/menus/side/SideMenu.axaml
+++ b/menus/side/SideMenu.axaml
@@ -10,6 +10,7 @@
                         <Setter Property="Foreground" Value="White"/>
                         <Setter Property="HorizontalAlignment" Value="Stretch"/>
                         <Setter Property="Margin" Value="2"/>
+                        <Setter Property="Height" Value="45"/>
                     </Style>
                     <Style Selector="Button:pointerover">
                         <Setter Property="Background" Value="#3b3b3b"/>
@@ -23,6 +24,7 @@
                         <Setter Property="Foreground" Value="White"/>
                         <Setter Property="HorizontalAlignment" Value="Stretch"/>
                         <Setter Property="Margin" Value="2"/>
+                        <Setter Property="Height" Value="45"/>
                     </Style>
                     <Style Selector="Button:pointerover">
                         <Setter Property="Background" Value="#3b3b3b"/>
@@ -36,6 +38,7 @@
                         <Setter Property="Foreground" Value="White"/>
                         <Setter Property="HorizontalAlignment" Value="Stretch"/>
                         <Setter Property="Margin" Value="2"/>
+                        <Setter Property="Height" Value="45"/>
                     </Style>
                     <Style Selector="Button:pointerover">
                         <Setter Property="Background" Value="#3b3b3b"/>
@@ -49,12 +52,13 @@
                     <TextBlock Text="Bibles" Foreground="White" Margin="2" HorizontalAlignment="Center" FontStyle="Italic"/>
                     <Button Content="Character" Tag="CharacterBible" Click="Button_Click">
                         <Button.Styles>
-                            <Style Selector="Button">
-                                <Setter Property="Background" Value="#2b2b2b"/>
-                                <Setter Property="Foreground" Value="White"/>
-                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                                <Setter Property="Margin" Value="2"/>
-                            </Style>
+                                <Style Selector="Button">
+                                    <Setter Property="Background" Value="#2b2b2b"/>
+                                    <Setter Property="Foreground" Value="White"/>
+                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                    <Setter Property="Margin" Value="2"/>
+                                    <Setter Property="Height" Value="45"/>
+                                </Style>
                             <Style Selector="Button:pointerover">
                                 <Setter Property="Background" Value="#3b3b3b"/>
                             </Style>
@@ -62,12 +66,13 @@
                     </Button>
                     <Button Content="Location" Tag="LocationBible" Click="Button_Click">
                         <Button.Styles>
-                            <Style Selector="Button">
-                                <Setter Property="Background" Value="#2b2b2b"/>
-                                <Setter Property="Foreground" Value="White"/>
-                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                                <Setter Property="Margin" Value="2"/>
-                            </Style>
+                                <Style Selector="Button">
+                                    <Setter Property="Background" Value="#2b2b2b"/>
+                                    <Setter Property="Foreground" Value="White"/>
+                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                    <Setter Property="Margin" Value="2"/>
+                                    <Setter Property="Height" Value="45"/>
+                                </Style>
                             <Style Selector="Button:pointerover">
                                 <Setter Property="Background" Value="#3b3b3b"/>
                             </Style>
@@ -75,12 +80,13 @@
                     </Button>
                     <Button Content="Items" Tag="ItemBible" Click="Button_Click">
                         <Button.Styles>
-                            <Style Selector="Button">
-                                <Setter Property="Background" Value="#2b2b2b"/>
-                                <Setter Property="Foreground" Value="White"/>
-                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                                <Setter Property="Margin" Value="2"/>
-                            </Style>
+                                <Style Selector="Button">
+                                    <Setter Property="Background" Value="#2b2b2b"/>
+                                    <Setter Property="Foreground" Value="White"/>
+                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                    <Setter Property="Margin" Value="2"/>
+                                    <Setter Property="Height" Value="45"/>
+                                </Style>
                             <Style Selector="Button:pointerover">
                                 <Setter Property="Background" Value="#3b3b3b"/>
                             </Style>
@@ -88,12 +94,13 @@
                     </Button>
                     <Button Content="Lore" Tag="LoreBible" Click="Button_Click">
                         <Button.Styles>
-                            <Style Selector="Button">
-                                <Setter Property="Background" Value="#2b2b2b"/>
-                                <Setter Property="Foreground" Value="White"/>
-                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                                <Setter Property="Margin" Value="2"/>
-                            </Style>
+                                <Style Selector="Button">
+                                    <Setter Property="Background" Value="#2b2b2b"/>
+                                    <Setter Property="Foreground" Value="White"/>
+                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                    <Setter Property="Margin" Value="2"/>
+                                    <Setter Property="Height" Value="45"/>
+                                </Style>
                             <Style Selector="Button:pointerover">
                                 <Setter Property="Background" Value="#3b3b3b"/>
                             </Style>

--- a/menus/top/TopMenu.axaml
+++ b/menus/top/TopMenu.axaml
@@ -1,8 +1,13 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="TheWordForge.menus.top.TopMenu">
-    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0">
-        <StackPanel>
+    <UserControl.Styles>
+        <Style Selector="Button">
+            <Setter Property="Height" Value="45"/>
+        </Style>
+    </UserControl.Styles>
+    <Grid ColumnDefinitions="*,Auto" VerticalAlignment="Center" Margin="10,0">
+        <StackPanel Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center">
             <TextBlock Text="Right Pane" Foreground="White" HorizontalAlignment="Center"/>
             <Border BorderBrush="White" BorderThickness="1" Padding="5">
                 <StackPanel Orientation="Horizontal" Spacing="5">
@@ -10,7 +15,7 @@
                     <Button x:Name="OutlineButton" Content="Outline" Click="OpenOutline"/>
                     <StackPanel>
                         <TextBlock Text="Bibles" Foreground="White" HorizontalAlignment="Center"/>
-                        <Border Background="Gray" Padding="5">
+                        <Border Background="Black" Padding="5">
                             <StackPanel Orientation="Horizontal" Spacing="5">
                                 <Button x:Name="CharacterBibleButton" Content="Character" Click="OpenCharacterBible"/>
                                 <Button x:Name="LocationBibleButton" Content="Location" Click="OpenLocationBible"/>
@@ -22,7 +27,7 @@
                 </StackPanel>
             </Border>
         </StackPanel>
-        <Button x:Name="CustomizeButton" Content="Customize" Margin="10,0,0,0" Click="OpenCustomize"/>
-    </StackPanel>
+        <Button x:Name="CustomizeButton" Grid.Column="1" HorizontalAlignment="Right" Content="Customize" Margin="10,0,0,0" Click="OpenCustomize"/>
+    </Grid>
 </UserControl>
 


### PR DESCRIPTION
## Summary
- Centered Right Pane controls, right-aligned the Customize button, and gave Bible buttons a black background.
- Reduced left pane width, expanded right pane, and doubled hamburger icon size.
- Increased button heights across top and side menus for a larger interface footprint.

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a7d0850d4c8330a7894ffed9f3fbc5