### PR TITLE
Handle startup window initialization with desktop startup

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -16,8 +16,11 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.MainWindow = new MainWindow();
-            var newProjectWindow = new NewProjectWindow();
-            newProjectWindow.Show(desktop.MainWindow);
+            desktop.Startup += (_, _) =>
+            {
+                var newProjectWindow = new NewProjectWindow();
+                newProjectWindow.Show(desktop.MainWindow);
+            };
         }
 
         base.OnFrameworkInitializationCompleted();


### PR DESCRIPTION
## Summary
- show new project dialog after desktop startup instead of immediately during framework initialization

## Testing
- `~/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a7e1182d6c83309367667f6cc28f9a