### PR TITLE
Add explicit App constructor for Avalonia

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -6,6 +6,11 @@ namespace TheWordForge;
 
 public partial class App : Application
 {
+    // Parameterless constructor required for Avalonia XAML loader
+    public App()
+    {
+    }
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);


### PR DESCRIPTION
## Summary
- add parameterless App constructor so Avalonia XAML loader can instantiate the application class

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68a7e3685414833090363c440223727d