### PR TITLE
0.1.2 – Fix Startup Owner Error for New Project Window

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -21,7 +21,8 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.MainWindow = new MainWindow();
-            desktop.Startup += (_, _) =>
+
+            desktop.MainWindow.Opened += (_, _) =>
             {
                 var newProjectWindow = new NewProjectWindow();
                 newProjectWindow.Show(desktop.MainWindow);


### PR DESCRIPTION
## Summary
- Display the New Project window after `MainWindow` opens so its owner is visible.
- Keep `MainWindow` registered as the desktop main window for proper application startup.

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a7e5855ce88330aeb0e3c2116f185c