### PR TITLE
fix: resolve loading errors

### DIFF
--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -1,7 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using TheWordForge.services;
-using System.Threading.Tasks;
 
 namespace TheWordForge;
 
@@ -37,14 +37,17 @@ public partial class MainWindow : Window
 
     private async void LoadProject(object? sender, RoutedEventArgs e)
     {
-        var dialog = new OpenFileDialog
+        var options = new FilePickerOpenOptions
         {
             AllowMultiple = false,
-            Filters = { new FileDialogFilter { Name = "Forge Project", Extensions = { "forge" } } }
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("Forge Project") { Patterns = new[] { "*.forge" } }
+            }
         };
-        var files = await dialog.ShowAsync(this);
-        if (files != null && files.Length > 0)
-            await ProjectService.LoadProjectAsync(files[0]);
+        var files = await StorageProvider.OpenFilePickerAsync(options);
+        if (files.Count > 0)
+            await ProjectService.LoadProjectAsync(files[0].Path.LocalPath);
     }
 
     private async void SaveProject(object? sender, RoutedEventArgs e)

--- a/NewProjectWindow.axaml.cs
+++ b/NewProjectWindow.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using System;
 using System.IO;
 using TheWordForge.services;
@@ -18,25 +19,27 @@ public partial class NewProjectWindow : Window
 
     private async void BrowseSaveLocation(object? sender, RoutedEventArgs e)
     {
-        var dialog = new OpenFolderDialog();
-        var result = await dialog.ShowAsync(this);
-        if (!string.IsNullOrEmpty(result) && DataContext is NewProjectViewModel vm)
+        var folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions());
+        if (folders.Count > 0 && DataContext is NewProjectViewModel vm)
         {
-            vm.SaveLocation = result;
+            vm.SaveLocation = folders[0].Path.LocalPath;
         }
     }
 
     private async void LoadExistingProject(object? sender, RoutedEventArgs e)
     {
-        var dialog = new OpenFileDialog
+        var options = new FilePickerOpenOptions
         {
             AllowMultiple = false,
-            Filters = { new FileDialogFilter { Name = "Forge Project", Extensions = { "forge" } } }
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("Forge Project") { Patterns = new[] { "*.forge" } }
+            }
         };
-        var files = await dialog.ShowAsync(this);
-        if (files != null && files.Length > 0)
+        var files = await StorageProvider.OpenFilePickerAsync(options);
+        if (files.Count > 0)
         {
-            await ProjectService.LoadProjectAsync(files[0]);
+            await ProjectService.LoadProjectAsync(files[0].Path.LocalPath);
             Close();
         }
     }

--- a/panels/TranscriptPanel.axaml.cs
+++ b/panels/TranscriptPanel.axaml.cs
@@ -62,9 +62,12 @@ public partial class TranscriptPanel : UserControl
             return;
 
         _dragItem = item.DataContext;
-        var data = new DataObject();
-        data.Set("application/x-treeitem", _dragItem);
-        await DragDrop.DoDragDrop(e, data, DragDropEffects.Move);
+        if (_dragItem != null)
+        {
+            var data = new DataObject();
+            data.Set("application/x-treeitem", _dragItem);
+            await DragDrop.DoDragDrop(e, data, DragDropEffects.Move);
+        }
     }
 
     private void TreeViewDragOver(object? sender, DragEventArgs e)
@@ -96,22 +99,22 @@ public partial class TranscriptPanel : UserControl
         if (targetItem == null || ReferenceEquals(targetItem, _dragItem))
             return;
 
-        if (_dragItem is Chapter draggedChapter && targetItem is Chapter targetChapter)
+        if (_dragItem is Chapter draggedChapter && targetItem is Chapter targetChapterObj)
         {
             var chapters = vm.Chapters;
             var oldIndex = chapters.IndexOf(draggedChapter);
-            var newIndex = chapters.IndexOf(targetChapter);
+            var newIndex = chapters.IndexOf(targetChapterObj);
             if (oldIndex >= 0 && newIndex >= 0)
             {
                 chapters.Move(oldIndex, newIndex);
             }
         }
-        else if (_dragItem is Chapter draggedCh && targetItem is Scene targetScene)
+        else if (_dragItem is Chapter draggedCh && targetItem is Scene targetSceneObj)
         {
             var chapters = vm.Chapters;
             var oldIndex = chapters.IndexOf(draggedCh);
-            var targetChapter = vm.Chapters.First(ch => ch.Scenes.Contains(targetScene));
-            var newIndex = chapters.IndexOf(targetChapter);
+            var containingChapter = vm.Chapters.First(ch => ch.Scenes.Contains(targetSceneObj));
+            var newIndex = chapters.IndexOf(containingChapter);
             if (oldIndex >= 0 && newIndex >= 0)
             {
                 chapters.Move(oldIndex, newIndex);
@@ -123,10 +126,10 @@ public partial class TranscriptPanel : UserControl
             Chapter destChapter;
             int insertIndex;
 
-            if (targetItem is Scene targetScene)
+            if (targetItem is Scene targetSceneItem)
             {
-                destChapter = vm.Chapters.First(ch => ch.Scenes.Contains(targetScene));
-                insertIndex = destChapter.Scenes.IndexOf(targetScene);
+                destChapter = vm.Chapters.First(ch => ch.Scenes.Contains(targetSceneItem));
+                insertIndex = destChapter.Scenes.IndexOf(targetSceneItem);
             }
             else if (targetItem is Chapter tc)
             {

--- a/viewmodels/TranscriptPanelViewModel.cs
+++ b/viewmodels/TranscriptPanelViewModel.cs
@@ -1,14 +1,11 @@
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using TheWordForge.models;
 
 namespace TheWordForge;
 
-public class TranscriptPanelViewModel : INotifyPropertyChanged
+public class TranscriptPanelViewModel
 {
     public ObservableCollection<Chapter> Chapters { get; } = new();
-
-    public event PropertyChangedEventHandler? PropertyChanged;
 
     public TranscriptPanelViewModel()
     {


### PR DESCRIPTION
## Summary
- guard drag item and rename variables to avoid scope errors
- use StorageProvider APIs for file and folder picking
- drop unused INotifyPropertyChanged implementation

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a8921481088330808cf8a80f3ded7a